### PR TITLE
Add null check before calling method channel to prevent null exception

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -999,7 +999,9 @@ public class FlutterBluePlugin implements FlutterPlugin, ActivityAware, MethodCa
                 new Runnable() {
                     @Override
                     public void run() {
-                        channel.invokeMethod(name, byteArray);
+                        if(channel != null) {
+                            channel.invokeMethod(name, byteArray);
+                        }
                     }
                 });
     }


### PR DESCRIPTION
A lot of error report on production app

```
Exception java.lang.NullPointerException:
  at com.pauldemarco.flutter_blue.FlutterBluePlugin$5.run (FlutterBluePlugin.java:1002)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8757)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
  ```