### PR TITLE
Add null check on manufacturer ble data

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/ProtoMaker.java
@@ -68,10 +68,12 @@ public class ProtoMaker {
             }
             // Manufacturer Specific Data
             SparseArray<byte[]> msd = scanRecord.getManufacturerSpecificData();
-            for (int i = 0; i < msd.size(); i++) {
-                int key = msd.keyAt(i);
-                byte[] value = msd.valueAt(i);
-                a.putManufacturerData(key, ByteString.copyFrom(value));
+            if( msd != null ) {
+                for (int i = 0; i < msd.size(); i++) {
+                    int key = msd.keyAt(i);
+                    byte[] value = msd.valueAt(i);
+                    a.putManufacturerData(key, ByteString.copyFrom(value));
+                }
             }
             // Service Data
             Map<ParcelUuid, byte[]> serviceData = scanRecord.getServiceData();


### PR DESCRIPTION
bug fix

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'int android.util.SparseArray.size()' on a null object reference
  at com.pauldemarco.flutter_blue.ProtoMaker.from (ProtoMaker.java:71)
  at com.pauldemarco.flutter_blue.FlutterBluePlugin$2.onScanResult (FlutterBluePlugin.java:779)
  at android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run (BluetoothLeScanner.java:578)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7050)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:494)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:965)
```