### PR TITLE
Fix CCCD_UUID format

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/ProtoMaker.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/ProtoMaker.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 
 public class ProtoMaker {
 
-    private static final UUID CCCD_UUID = UUID.fromString("000002902-0000-1000-8000-00805f9b34fb");
+    private static final UUID CCCD_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
     static Protos.ScanResult from(BluetoothDevice device, byte[] advertisementData, int rssi) {
         Protos.ScanResult.Builder p = Protos.ScanResult.newBuilder();


### PR DESCRIPTION
This PR is to correct the format of CCCD_UUID in flutter_blue plugin.
OneApp will crash on Android 14 because of this.

A valid UUID string should be in the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (32 hexadecimal digits separated by hyphens).

You may wonder:
Why this works previously , and only crash on Android 14 and above?

Answer: Android 14 do more strict checking. Official document is here. https://developer.android.com/about/versions/14/behavior-changes-14

> UUID handling: The [java.util.UUID.fromString()](https://developer.android.com/reference/java/util/UUID#fromString(java.lang.String)) method now does more strict checks when validating the input argument, so you might see an IllegalArgumentException during deserialization. To enable or disable this change while testing, toggle the ENABLE_STRICT_VALIDATION flag using the [compatibility framework tools](https://developer.android.com/guide/app-compatibility/test-debug#toggle-dev-options).